### PR TITLE
fix(apca-silver-plus): don't reverse in place

### DIFF
--- a/.changeset/sharp-bats-remember.md
+++ b/.changeset/sharp-bats-remember.md
@@ -1,0 +1,5 @@
+---
+"apca-check": patch
+---
+
+fix: bug with array reversal

--- a/src/apca-silver-plus.ts
+++ b/src/apca-silver-plus.ts
@@ -30,8 +30,9 @@ const APCASilverPlusConformanceThresholdFn: ConformanceThresholdFn = (
     // Go over the table backwards to find the first matching font size and then the weight.
     // The value null is returned when the combination of font size and weight does not have
     // any elegible APCA luminosity silver compliant thresholds (represented by -1 in the table).
-    silverPlusAPCALookupTable.reverse();
-    for (const [rowSize, ...rowWeights] of silverPlusAPCALookupTable) {
+    const reversedTable = [...silverPlusAPCALookupTable].reverse();
+
+    for (const [rowSize, ...rowWeights] of reversedTable) {
         if (size >= rowSize) {
             for (const [idx, keywordWeight] of [
                 900, 800, 700, 600, 500, 400, 300, 200, 100,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -235,5 +235,22 @@ describe("apca-check", () => {
 
             await expect(apcaViolations[0].nodes.length).to.equal(3);
         });
+
+        it("should handle both valid code and violations", async () => {
+            const el: HTMLElement = await fixture(
+                html`<div style="background: white; color: black;">
+                    <p style="font-size: 12px; font-weight: 400;">Some copy</p>
+                    <p style="font-size: 16px; font-weight: 600;">Some copy</p>
+                </div>`,
+            );
+
+            const results = await runAxe(el);
+
+            const apcaViolations = results.violations.filter((violation) =>
+                violation.id.includes("color-contrast-apca-silver"),
+            );
+
+            await expect(apcaViolations[0].nodes.length).to.equal(1);
+        });
     });
 });


### PR DESCRIPTION
Hey folks, I found a small issue with the `silver` check:

we were reversing the array in place, which meant the array was being reversed and re-reversed. I switched it to reverse a copy of the original array, so that we don't taint it.